### PR TITLE
Update track.py

### DIFF
--- a/src/pycrumbs/track.py
+++ b/src/pycrumbs/track.py
@@ -314,6 +314,8 @@ def write_record(
 
     """
     # Save the record to file
+    if not record_path.name.endswith('.json'):
+        record_path = record_path.with_name(record_path.stem + '.json')
     with record_path.open('w') as jf:
         json.dump(record, jf, indent=4)
 


### PR DESCRIPTION
Add record chaining to `tracked` with the `chain_records` argument. If the `full_record_path` already exists, the previous record is read and the new record file will be appended to a list containing any previous records. If `full_record_path` does not exist, it works as normal. `chain_records` defaults to `False` with the assumption that most commands are not intended to continually add to the same directory / record over time.