### PR TITLE
Remove typehint for older pythons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pycrumbs"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tool for automatically storing information about Python processes."
 authors = ["Chris Bridge <chrisbridge44@gmail.com>"]
 license = "MIT"

--- a/src/pycrumbs/track.py
+++ b/src/pycrumbs/track.py
@@ -338,7 +338,7 @@ def tracked(
     record_filename: Optional[str] = None,
     extra_modules: Optional[Sequence[Union[str, ModuleType]]] = None,
     extra_environment_variables: Optional[Sequence[str]] = None,
-    seed_parameter: str | None = None,
+    seed_parameter: Optional[str] = None,
     seed_numpy: bool = True,
     seed_tensorflow: bool = True,
     seed_torch: bool = True,


### PR DESCRIPTION
remove a "new-style" type hint that made the library on pythons before 3.10