### PR TITLE
`pkg_resources` deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pycrumbs"
-version = "0.3.1"
+version = "0.4.0"
 description = "Tool for automatically storing information about Python processes."
 authors = ["Chris Bridge <chrisbridge44@gmail.com>"]
 license = "MIT"

--- a/src/pycrumbs/track.py
+++ b/src/pycrumbs/track.py
@@ -9,7 +9,7 @@ import multiprocessing as mp
 from os import environ, getcwd
 from pathlib import Path
 import importlib
-import pkg_resources
+import importlib.metadata
 import platform
 import random
 import sys
@@ -302,7 +302,7 @@ def get_installed_packages() -> Dict[str, str]:
 
     """
     return {
-        p.key: p.version for p in pkg_resources.working_set
+        p.name: p.version for p in importlib.metadata.distributions()
     }
 
 


### PR DESCRIPTION
`pkg_resources` is deprecated, leading to warnings when importing pycrumbs.

This PR migrates from `pkg_resources` to the `importlib.metadata` for finding python distributions in the current environment